### PR TITLE
Event listener for stock update

### DIFF
--- a/app/code/community/SixBySix/RealTimeDespatch/Model/Service/Importer/Inventory.php
+++ b/app/code/community/SixBySix/RealTimeDespatch/Model/Service/Importer/Inventory.php
@@ -90,6 +90,12 @@ class SixBySix_RealTimeDespatch_Model_Service_Importer_Inventory extends SixBySi
                 );
             }
         }
+        
+        // Only fire pre-instantiated objects to reduce overhead.
+        $productArray = array('product_id' => $productId,
+	                          'stock' => $stock);
+
+	    Mage::dispatchEvent('catalog_product_stock_save_after', $productArray);
 
         $report->setLines($reportLines);
 


### PR DESCRIPTION
Added an event listener for stock updates. Mostly handy for those out there who have custom caching architectures (like us at Dobell), so we can take the product id that has been updated and with some logic invalidate the cache entry if it is required.
